### PR TITLE
fix: avoid Route facade call introduced in laravel/horizon v5.45.0

### DIFF
--- a/src/Providers/HorizonServiceProvider.php
+++ b/src/Providers/HorizonServiceProvider.php
@@ -63,7 +63,13 @@ class HorizonServiceProvider extends Provider
         $this->registerQueueConnectors();
         $this->registerNotificationDispatcher();
 
-        parent::boot();
+        // We intentionally do not call parent::boot() here.
+        // laravel/horizon v5.45.0 introduced an inline Route::middlewareGroup() call at the
+        // top of parent::boot() which uses the Route facade. Flarum never sets a facade root,
+        // so this throws "A facade root has not been set." instead of calling parent::boot()
+        // we replicate only the two calls that fof/horizon actually needs.
+        $this->normalizeConfig();
+        $this->registerEvents();
     }
 
     protected function registerNotificationDispatcher(): void


### PR DESCRIPTION
## Summary

`laravel/horizon` v5.45.0 added an inline `Route::middlewareGroup()` call at the top of `HorizonServiceProvider::boot()`. The `Route` facade requires a facade root to be set, which Flarum never does, causing a boot error immediately on app startup:

```
RuntimeException: A facade root has not been set.
  in vendor/illuminate/support/Facades/Facade.php:360
  thrown from FoF\Horizon\Providers\HorizonServiceProvider->boot()
```

## Fix

`fof/horizon` already overrides `registerRoutes()`, `registerResources()`, `offerPublishing()`, and `registerCommands()` as empty stubs, so calling `parent::boot()` only served to invoke `normalizeConfig()` and `registerEvents()`. This PR calls those two methods directly instead of delegating to `parent::boot()`, skipping the problematic facade call entirely.

The middleware group registered by the parent (`horizon` group with `SentinelMiddleware`) is irrelevant to `fof/horizon` — its routes are registered through Flarum's own `Extend\Routes('admin')` extender, which handles access control via Flarum's admin middleware stack.

**Backwards compatible** — `normalizeConfig()` and `registerEvents()` have existed since well before `^5.40.0`.

## Test plan

- [ ] Upgrade `laravel/horizon` to `^5.45.0` and confirm the app boots without error
- [ ] Verify the Horizon dashboard is still accessible and functional in the admin panel
- [ ] Confirm queue workers still start correctly via `php flarum horizon`

🤖 Generated with [Claude Code](https://claude.com/claude-code)