### PR TITLE
[1.x] fix: normalise phpredis INFO array into nested section structure

### DIFF
--- a/src/Traits/RetrievesRedisInfo.php
+++ b/src/Traits/RetrievesRedisInfo.php
@@ -19,8 +19,26 @@ trait RetrievesRedisInfo
     {
         try {
             $connection = $this->redis->connection();
+            $info = $connection->info();
 
-            return $connection->info();
+            // Predis returns a nested array keyed by section name (e.g. ['Memory' => [...]]).
+            // phpredis returns a flat array. Normalise the flat format into nested sections
+            // so that Arr::get($info, 'Memory.maxmemory_policy') works with both drivers.
+            if (!isset($info['Memory']) || !is_array($info['Memory'])) {
+                $sections = ['server', 'clients', 'memory', 'stats', 'replication', 'cpu', 'keyspace'];
+                $nested = [];
+
+                foreach ($sections as $section) {
+                    $sectionData = $connection->info($section);
+                    if (is_array($sectionData) && !empty($sectionData)) {
+                        $nested[ucfirst($section)] = $sectionData;
+                    }
+                }
+
+                $info = $nested;
+            }
+
+            return $info;
         } catch (\Exception $e) {
             // Catch the exception if Redis is not configured or unavailable
             return [


### PR DESCRIPTION
## Problem

After switching from Predis to phpredis (`ext-redis`), the Horizon dashboard stopped displaying Redis stats (memory usage, memory policy, connected clients, ops/sec).

**Root cause:** `phpredis` returns a flat array from `info()` with all fields at the top level:
```php
['used_memory' => ..., 'maxmemory_policy' => ..., 'connected_clients' => ...]
```

**Predis** returns a nested array keyed by section name:
```php
['Memory' => ['used_memory' => ..., 'maxmemory_policy' => ...], 'Clients' => [...]]
```

`Stats.php` uses `Arr::get($info, 'Memory.maxmemory_policy', '')` which requires the nested format, so all values came back empty with phpredis.

## Fix

In `RetrievesRedisInfo::getInfo()`, detect whether the result is flat (no `Memory` key) and if so, re-fetch each section individually via `info($section)` and assemble into the Predis-compatible nested structure. If Predis is in use the array is already nested and is returned as-is.

## Test plan

- [ ] Enable `ext-redis` (phpredis) — Horizon dashboard Redis stats panel shows memory used, memory max, memory policy, ops/sec, connected clients
- [ ] With Predis (no `ext-redis`) — dashboard continues to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)