### PR TITLE
[2.x] fix: normalise phpredis INFO array into nested section structure

### DIFF
--- a/src/Traits/RetrievesRedisInfo.php
+++ b/src/Traits/RetrievesRedisInfo.php
@@ -20,12 +20,37 @@ trait RetrievesRedisInfo
     /**
      * Retrieves Redis info with error handling.
      *
+     * phpredis returns a flat array from `info()`, while Predis returns a nested
+     * array keyed by section name (e.g. `['Memory' => [...]]`). Stats.php uses
+     * dot-notation lookups like `Arr::get($info, 'Memory.maxmemory_policy')` which
+     * require the nested format. Normalise the flat phpredis output into sections.
+     *
      * @return array
      */
     protected function getInfo(): array
     {
         try {
-            return $this->redis->connection()->info();
+            $connection = $this->redis->connection();
+            $info = $connection->info();
+
+            // If already nested (Predis-style), return as-is.
+            if (isset($info['Memory']) && is_array($info['Memory'])) {
+                return $info;
+            }
+
+            // phpredis returns a flat array — rebuild into section-keyed structure
+            // by fetching each section individually.
+            $sections = ['server', 'clients', 'memory', 'stats', 'replication', 'cpu', 'keyspace'];
+            $nested = [];
+
+            foreach ($sections as $section) {
+                $sectionData = $connection->info($section);
+                if (is_array($sectionData) && !empty($sectionData)) {
+                    $nested[ucfirst($section)] = $sectionData;
+                }
+            }
+
+            return $nested;
         } catch (Exception $e) {
             return [
                 'error' => 'Redis connection failed: '.$e->getMessage(),


### PR DESCRIPTION
## Problem

After switching from Predis to phpredis (`ext-redis`), the Horizon dashboard stopped displaying Redis stats (memory usage, memory policy, connected clients, ops/sec).

**Root cause:** `phpredis` returns a flat array from `info()` with all fields at the top level:
```php
['used_memory' => ..., 'maxmemory_policy' => ..., 'connected_clients' => ...]
```

**Predis** returns a nested array keyed by section name:
```php
['Memory' => ['used_memory' => ..., 'maxmemory_policy' => ...], 'Clients' => [...]]
```

`Stats.php` uses `Arr::get($info, 'Memory.maxmemory_policy', '')` which requires the nested format, so all values came back empty with phpredis.

## Fix

In `RetrievesRedisInfo::getInfo()`, detect whether the result is flat (no `Memory` key) and if so, re-fetch each section individually via `info($section)` and assemble into the Predis-compatible nested structure. If Predis is in use the array is already nested and is returned as-is.

## Test plan

- [ ] Enable `ext-redis` (phpredis) — Horizon dashboard Redis stats panel shows memory used, memory max, memory policy, ops/sec, connected clients
- [ ] With Predis (no `ext-redis`) — dashboard continues to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)