### PR TITLE
chore: upgrade to Laravel 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require": {
         "flarum/core": "^2.0.0",
-        "laravel/horizon": "^5.40.0",
+        "laravel/horizon": "^5.45.4",
         "fof/redis": "^2.0.0",
         "vlucas/phpdotenv": "^5.2"
     },


### PR DESCRIPTION
## Summary

- Bumps \`laravel/horizon\` from \`^5.40.0\` to \`^5.45.4\`, the first release with \`illuminate ^13.0\` support

No PHP source changes required — \`HorizonServiceProvider\` already intentionally skips \`parent::boot()\` (where Horizon v5.45 introduced the new \`Route\`/\`SentinelMiddleware\` calls), so the upgrade is transparent.

## Related

- flarum/framework: https://github.com/flarum/framework/pull/4468
- fof/redis: https://github.com/FriendsOfFlarum/redis/pull/22