### PR TITLE
[2.x] fix: explicitly set master supervisor and per-worker memory limits to 128 MB

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,14 +424,41 @@ sudo supervisorctl restart horizon
 
 ### Memory issues
 
-**Issue:** Workers consuming too much memory
+**Issue:** Workers consuming too much memory, or you see `Memory limit exceeded: Using X/128MB. Consider increasing horizon.memory_limit.`
 
-**Solution:** Adjust memory limits in your Horizon config:
+There are two separate memory limits:
+
+- **`memory_limit`** — the master supervisor process. When exceeded, Horizon restarts itself gracefully. Default: 128 MB.
+- **`memory`** (per supervisor) — each individual worker process. When exceeded after a job completes, the worker is recycled. Default: 128 MB.
+
+**Solution:** Override either limit via `config.php`:
+
+```php
+'horizon' => [
+    'memory_limit' => 256, // MB — master supervisor
+],
+```
+
+Or via the `Horizon` extender in `extend.php`:
+
+```php
+(new \FoF\Horizon\Extend\Horizon)->config([
+    'memory_limit' => 256, // MB — master supervisor
+    'environments' => [
+        'production' => [
+            'supervisor-1' => [
+                'memory' => 256, // MB — per worker
+            ],
+        ],
+    ],
+]),
+```
+
+You can also limit how long a worker runs before being recycled:
 
 ```php
 'defaults' => [
     'supervisor-1' => [
-        'memory' => 128, // MB
         'maxJobs' => 1000, // Restart after X jobs
         'maxTime' => 3600, // Restart after X seconds
     ],

--- a/src/Providers/HorizonServiceProvider.php
+++ b/src/Providers/HorizonServiceProvider.php
@@ -170,6 +170,8 @@ class HorizonServiceProvider extends Provider
         Arr::set($config, 'env', $env);
         Arr::set($config, 'path', trim($path, '/').'/horizon');
         Arr::set($config, 'use', 'horizon');
+        Arr::set($config, 'memory_limit', 128);
+
         Arr::set($config, 'environments', [
             $env => [
                 'supervisor-1' => [
@@ -178,6 +180,7 @@ class HorizonServiceProvider extends Provider
                     'balance'    => 'auto',
                     'processes'  => 4,
                     'tries'      => 3,
+                    'memory'     => 128,
                 ],
             ],
         ]);


### PR DESCRIPTION
Previously neither `memory_limit` (master supervisor) nor `memory` (per-worker) were explicitly set, leaving both to fall through to Horizon's own defaults. This sets both to 128 MB, consistent with each other, and documents both limits in the README troubleshooting section.

Both values can be overridden via `config.php` or the `Horizon` extender.